### PR TITLE
Allow manually enabling Istio integration

### DIFF
--- a/charms/jupyter-controller/config.yaml
+++ b/charms/jupyter-controller/config.yaml
@@ -3,3 +3,7 @@ options:
     type: boolean
     default: true
     description: Enables culling of idle Jupyter pods
+  use-istio:
+    type: boolean
+    default: false
+    description: Manually enable Istio integration, instead of via relations

--- a/charms/jupyter-controller/reactive/jupyter_controller.py
+++ b/charms/jupyter-controller/reactive/jupyter_controller.py
@@ -84,7 +84,9 @@ def start_charm():
                     'name': 'jupyter-controller',
                     'command': ['/manager'],
                     'config': {
-                        'USE_ISTIO': str(hookenv.is_relation_made('service-mesh')).lower(),
+                        'USE_ISTIO': str(
+                            config['use-istio'] or hookenv.is_relation_made('service-mesh')
+                        ).lower(),
                         'ISTIO_GATEWAY': f'{model}/kubeflow-gateway',
                         'ENABLE_CULLING': config['enable-culling'],
                     },


### PR DESCRIPTION
Adds `use-istio` config option that allows manually enabling Istio integration, instead of relying on relations being made.